### PR TITLE
Segue from the NewReminderDetailVC, to the CameraVC and the PhotoPreviewVC, then pop back to the NRDetailVC

### DIFF
--- a/Remage/Storyboards/NewReminder.storyboard
+++ b/Remage/Storyboards/NewReminder.storyboard
@@ -204,7 +204,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h3r-kA-61w">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
@@ -217,15 +217,24 @@
                         <viewLayoutGuide key="safeArea" id="WMu-6f-AqC"/>
                     </view>
                     <navigationItem key="navigationItem" id="Ubv-4J-wEU">
-                        <barButtonItem key="rightBarButtonItem" systemItem="save" id="tp4-r8-USm">
-                            <connections>
-                                <action selector="saveButtonTapped:" destination="cEK-pu-c47" id="iXj-6T-ESI"/>
-                            </connections>
-                        </barButtonItem>
+                        <rightBarButtonItems>
+                            <barButtonItem systemItem="save" id="tp4-r8-USm">
+                                <connections>
+                                    <action selector="saveButtonTapped:" destination="cEK-pu-c47" id="iXj-6T-ESI"/>
+                                </connections>
+                            </barButtonItem>
+                            <barButtonItem title="Details" id="agx-2Z-dX7">
+                                <connections>
+                                    <action selector="detailsBarButtonTapped:" destination="cEK-pu-c47" id="I32-cX-hqT"/>
+                                </connections>
+                            </barButtonItem>
+                        </rightBarButtonItems>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
+                        <outlet property="detailsBarButton" destination="agx-2Z-dX7" id="CJo-z6-7Ja"/>
                         <outlet property="imageView" destination="h3r-kA-61w" id="CoM-jQ-RrB"/>
+                        <outlet property="saveBarButton" destination="tp4-r8-USm" id="vcy-Bz-QTu"/>
                         <segue destination="ftG-iM-aUh" kind="show" identifier="PhotoPreviewToNewReminderDetailSegue" id="JAA-r4-BaZ"/>
                     </connections>
                 </viewController>
@@ -582,7 +591,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="F7Y-UV-5wD"/>
+        <segue reference="JAA-r4-BaZ"/>
         <segue reference="szR-xT-rSi"/>
     </inferredMetricsTieBreakers>
     <resources>

--- a/Remage/Storyboards/NewReminder.storyboard
+++ b/Remage/Storyboards/NewReminder.storyboard
@@ -466,6 +466,7 @@
                         <outlet property="setTimeLabel" destination="tTV-F4-6QM" id="aYZ-cb-DXI"/>
                         <outlet property="timePickerTextField" destination="ajN-R7-TAH" id="JZS-be-eu3"/>
                         <outlet property="titleTextField" destination="vHe-Z8-EPF" id="szP-xC-Mf2"/>
+                        <segue destination="c5m-7Q-zza" kind="show" identifier="ShowCameraFromNRDetailsVC" id="szR-xT-rSi"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="eSH-0c-vT1" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -582,6 +583,7 @@
     </scenes>
     <inferredMetricsTieBreakers>
         <segue reference="F7Y-UV-5wD"/>
+        <segue reference="szR-xT-rSi"/>
     </inferredMetricsTieBreakers>
     <resources>
         <image name="bolt" catalog="system" width="101" height="128"/>

--- a/Remage/View Controllers/New Reminder SB/CameraViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/CameraViewController.swift
@@ -25,6 +25,7 @@ class CameraViewController: UIViewController {
     
     var image: UIImage?
     var didStartNewReminder: Bool?
+    var nrDetailDelegate: ImageSelectionDelegate?
     
     // MARK: - Outlets
     
@@ -117,6 +118,7 @@ class CameraViewController: UIViewController {
             photoPreviewVC.themeController = themeController
             photoPreviewVC.image = image
             photoPreviewVC.didStartNewReminder = didStartNewReminder
+            photoPreviewVC.nrDetailDelegate = nrDetailDelegate
         }
     }
 }

--- a/Remage/View Controllers/New Reminder SB/CameraViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/CameraViewController.swift
@@ -24,6 +24,7 @@ class CameraViewController: UIViewController {
     var videoOutput: AVCaptureMovieFileOutput?
     
     var image: UIImage?
+    var didStartNewReminder: Bool?
     
     // MARK: - Outlets
     
@@ -115,6 +116,7 @@ class CameraViewController: UIViewController {
             photoPreviewVC.reminderController = reminderController
             photoPreviewVC.themeController = themeController
             photoPreviewVC.image = image
+            photoPreviewVC.didStartNewReminder = didStartNewReminder
         }
     }
 }

--- a/Remage/View Controllers/New Reminder SB/NewReminderDetailViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/NewReminderDetailViewController.swift
@@ -24,6 +24,7 @@ class NewReminderDetailViewController: UIViewController {
     var noteRecieved: String?
     var oldNote: String?
     var didShowNewNoteAlert = false
+    var didStartNewReminder = true
     
     let datePicker = UIDatePicker()
     let timePicker = UIDatePicker()
@@ -471,6 +472,7 @@ class NewReminderDetailViewController: UIViewController {
             cameraVC.themeController = themeController
             cameraVC.reminderController = reminderController
             cameraVC.cameraController = cameraController
+            cameraVC.didStartNewReminder = didStartNewReminder
         }
     }
 }

--- a/Remage/View Controllers/New Reminder SB/NewReminderDetailViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/NewReminderDetailViewController.swift
@@ -70,6 +70,7 @@ class NewReminderDetailViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setBGColors()
+        tryDisplayImageFromCamera()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -189,6 +190,13 @@ class NewReminderDetailViewController: UIViewController {
     }
     
     // MARK: - Methods
+    
+    // If recieved the image from the camera, display it
+    private func tryDisplayImageFromCamera() {
+        if let image = imageFromCamera {
+            imageView.image = image
+        }
+    }
     
     // Alert User if the Note was recived
     private func tryShowNoteRecivedAlert() {
@@ -380,11 +388,6 @@ class NewReminderDetailViewController: UIViewController {
     
     private func updateViews() {
         
-        // Show image if segue from CameraVC
-        if let image = imageFromCamera {
-            imageView.image = image
-        }
-        
         // Round corners
         imageView.layer.cornerRadius = 20
         addImagesButton.layer.cornerRadius = 15
@@ -472,7 +475,9 @@ class NewReminderDetailViewController: UIViewController {
             cameraVC.themeController = themeController
             cameraVC.reminderController = reminderController
             cameraVC.cameraController = cameraController
+            
             cameraVC.didStartNewReminder = didStartNewReminder
+            cameraVC.nrDetailDelegate = self
         }
     }
 }
@@ -482,7 +487,6 @@ class NewReminderDetailViewController: UIViewController {
 // ImagePicker Delegate Protocols
 extension NewReminderDetailViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
 
-    
     // Try to get image
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
@@ -513,5 +517,12 @@ extension NewReminderDetailViewController: UIImagePickerControllerDelegate, UINa
 extension NewReminderDetailViewController: GetNoteDelegate {
     func get(note: String) {
         noteRecieved = note
+    }
+}
+
+// Get the image from PhotoPreviewVC
+extension NewReminderDetailViewController: ImageSelectionDelegate {
+    func didChoose(image: UIImage) {
+        imageFromCamera = image
     }
 }

--- a/Remage/View Controllers/New Reminder SB/NewReminderDetailViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/NewReminderDetailViewController.swift
@@ -14,6 +14,7 @@ class NewReminderDetailViewController: UIViewController {
     
     var themeController: ThemeController?
     var reminderController: ReminderController?
+    var cameraController: CameraController?
     
     var image: UIImage?
     var imageFromCamera: UIImage?
@@ -255,7 +256,8 @@ class NewReminderDetailViewController: UIViewController {
         
         let camera = UIAlertAction(title: "Camera", style: .default) { action in
             
-            // TODO: - Go to Camera
+            // Go to CameraVC
+            self.performSegue(withIdentifier: "ShowCameraFromNRDetailsVC", sender: self)
         }
         
         let photoLibrary = UIAlertAction(title: "Photo Library", style: .default) { action in
@@ -450,7 +452,7 @@ class NewReminderDetailViewController: UIViewController {
     }
     
     // MARK: - Navigation
-
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         
         // Segue to NRNote
@@ -460,6 +462,15 @@ class NewReminderDetailViewController: UIViewController {
             noteVC.note = noteRecieved
             noteVC.getNoteDelegate = self
             noteVC.themeController = themeController
+        }
+            
+        // Segue to CameraVC
+        else if segue.identifier == "ShowCameraFromNRDetailsVC" {
+            guard let cameraVC = segue.destination as? CameraViewController else { return }
+            
+            cameraVC.themeController = themeController
+            cameraVC.reminderController = reminderController
+            cameraVC.cameraController = cameraController
         }
     }
 }

--- a/Remage/View Controllers/New Reminder SB/NewReminderTypeViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/NewReminderTypeViewController.swift
@@ -110,6 +110,7 @@ class NewReminderTypeViewController: UIViewController {
             
             newReminderDetailVC.reminderController = self.reminderController
             newReminderDetailVC.themeController = themeController
+            newReminderDetailVC.cameraController = cameraController
         }
     }
 }

--- a/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
@@ -21,6 +21,8 @@ class PhotoPreviewViewController: UIViewController {
     // MARK: - Outlets
     
     @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var detailsBarButton: UIBarButtonItem!
+    @IBOutlet weak var saveBarButton: UIBarButtonItem!
     
     // MARK: - DidLoad
     override func viewDidLoad() {
@@ -29,7 +31,16 @@ class PhotoPreviewViewController: UIViewController {
         updateViews()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        setBGColors()
+    }
+    
     // MARK: - Actions
+    
+    @IBAction func detailsBarButtonTapped(_ sender: UIBarButtonItem) {
+        segueToAddDetails()
+    }
     
     @IBAction func saveButtonTapped(_ sender: UIBarButtonItem) {
         savePhoto()
@@ -37,12 +48,26 @@ class PhotoPreviewViewController: UIViewController {
     
     // MARK: - Methods
     
-    // Save image in Photo Album
+    // Segue to NewReminderDetailVC to add more details to this Reminder
+    private func segueToAddDetails() {
+        performSegue(withIdentifier: "PhotoPreviewToNewReminderDetailSegue", sender: self)
+        
+        // TODO: - From SettingsVC, allow the user to set if the image should be saved to the camera roll
+        // after tapping on this button
+        
+        // Save the image in the Photo Library
+        //UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+    }
+    
+    // Save image in Photo Album and pop to a VC
     private func savePhoto() {
         guard let image = image else { return }
         
+        // Save the image in the Photo Library
         UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
         
+        // If the user came from the NewReminderDetailVC,
+        // pop to that NewReminderDetailVC
         if let didStartNewReminder = didStartNewReminder,
             didStartNewReminder {
             
@@ -54,18 +79,39 @@ class PhotoPreviewViewController: UIViewController {
                     // TODO: - Create a delegate protocol to bring this image to the NewReminderDetailVC
                 }
             }
+        // If the user did NOT come from the NewReminderDetailVC, popToRootVC
         } else {
             navigationController?.popToRootViewController(animated: true)
-            
-            // TODO: - Create a new button for "Details" in case the user wants to edit the details right now
-            // The "Save" button should say "Save photo only" or something like that cause it will popToRootVC
         }
-        //performSegue(withIdentifier: "PhotoPreviewToNewReminderDetailSegue", sender: self)
     }
+    
+    // MARK: - Update Views
     
     private func updateViews() {
         guard let image = image else { return }
         imageView.image = image
+    }
+    
+    // Background Colors Setup
+    private func setBGColors() {
+        
+        // Get BGColor
+        guard let themeController = themeController,
+            let color = themeController.currentColor else { return }
+        
+        // Background
+        view.backgroundColor = color.bgColor
+        
+        // Set NavigationBar and TabBar Colors
+        let textAttribute = [NSAttributedString.Key.foregroundColor: color.fontColor]
+        navigationController?.navigationBar.titleTextAttributes = textAttribute
+        
+        navigationController?.navigationBar.tintColor = color.barTintColor // Bar buttons
+        navigationController?.navigationBar.barTintColor = color.barBGTintColor // Entire bar BG color
+        
+        tabBarController?.tabBar.barTintColor = color.barBGTintColor // Entire bar BG color
+        tabBarController?.tabBar.tintColor = color.barTintColor // Selected tab bar button
+        tabBarController?.tabBar.unselectedItemTintColor = color.barUnselectedTintColor // Unselected bar buttons
     }
     
     // MARK: - Navigation

--- a/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
@@ -90,6 +90,14 @@ class PhotoPreviewViewController: UIViewController {
     private func updateViews() {
         guard let image = image else { return }
         imageView.image = image
+        
+        // Disabled the Details bar button if the User came from
+        // NewReminderDetailVC
+        if let didStartNewReminder = didStartNewReminder,
+            didStartNewReminder {
+            detailsBarButton.isEnabled = false
+            detailsBarButton.tintColor = .clear
+        }
     }
     
     // Background Colors Setup

--- a/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+protocol ImageSelectionDelegate {
+    func didChoose(image: UIImage)
+}
+
 class PhotoPreviewViewController: UIViewController {
     
     // MARK: - Properties
@@ -17,6 +21,7 @@ class PhotoPreviewViewController: UIViewController {
     
     var image: UIImage?
     var didStartNewReminder: Bool?
+    var nrDetailDelegate: ImageSelectionDelegate?
     
     // MARK: - Outlets
     
@@ -71,12 +76,16 @@ class PhotoPreviewViewController: UIViewController {
         if let didStartNewReminder = didStartNewReminder,
             didStartNewReminder {
             
+            // Find the NewReminderDetailVC
             for controller in self.navigationController!.viewControllers as Array {
                 if controller.isKind(of: NewReminderDetailViewController.self) {
                     self.navigationController!.popToViewController(controller, animated: true)
-                    break
                     
-                    // TODO: - Create a delegate protocol to bring this image to the NewReminderDetailVC
+                    // Bring this image to the NewReminderDetailVC
+                    if let nrDetailDelegate = nrDetailDelegate {
+                        nrDetailDelegate.didChoose(image: image)
+                    }
+                    break
                 }
             }
         // If the user did NOT come from the NewReminderDetailVC, popToRootVC

--- a/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
+++ b/Remage/View Controllers/New Reminder SB/PhotoPreviewViewController.swift
@@ -16,6 +16,7 @@ class PhotoPreviewViewController: UIViewController {
     var reminderController: ReminderController?
     
     var image: UIImage?
+    var didStartNewReminder: Bool?
     
     // MARK: - Outlets
     
@@ -41,8 +42,25 @@ class PhotoPreviewViewController: UIViewController {
         guard let image = image else { return }
         
         UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
-        //navigationController?.popToRootViewController(animated: true)
-        performSegue(withIdentifier: "PhotoPreviewToNewReminderDetailSegue", sender: self)
+        
+        if let didStartNewReminder = didStartNewReminder,
+            didStartNewReminder {
+            
+            for controller in self.navigationController!.viewControllers as Array {
+                if controller.isKind(of: NewReminderDetailViewController.self) {
+                    self.navigationController!.popToViewController(controller, animated: true)
+                    break
+                    
+                    // TODO: - Create a delegate protocol to bring this image to the NewReminderDetailVC
+                }
+            }
+        } else {
+            navigationController?.popToRootViewController(animated: true)
+            
+            // TODO: - Create a new button for "Details" in case the user wants to edit the details right now
+            // The "Save" button should say "Save photo only" or something like that cause it will popToRootVC
+        }
+        //performSegue(withIdentifier: "PhotoPreviewToNewReminderDetailSegue", sender: self)
     }
     
     private func updateViews() {


### PR DESCRIPTION
- Creating the segue and implementations that takes the User from the NewReminderDetailVC to the CameraVC, and then come back to the already loaded NewReminderDetailVC. The User can take a picture, then return to the NewReminderDetailVC that already exists in the Stack so the previous info added to this incomplete Reminder is still intact.
- Built the ImageSelectionDelegate Protocol, so the image taken from the CameraVC is added to the NewReminderDtailVC upon return from the Camera
- Added a "Details" button to the PhotoPreviewVC so the User can decide if to save the Reminder only with an Image, or segue to the Details page to add more details 